### PR TITLE
Adding attributes to all blocks including core block

### DIFF
--- a/includes/content-visibility.php
+++ b/includes/content-visibility.php
@@ -34,10 +34,6 @@ add_filter( 'register_block_type_args', __NAMESPACE__ . '\\add_block_default_att
  * @since 0.2.8
  */
 function add_block_default_attributes( $args, $name ) {
-	
-	if( str_starts_with( $name, 'core/' ) ) {
-		return $args;
-	}
 
 	$args['attributes']['contentVisibilityRules'] = array(
 		'type' => 'object',


### PR DESCRIPTION
Since some of the core blocks are also using the ServerSideRender component. A decision has been made to add the additional attributes to all blocks including core blocks. Blocks that uses the ServerSideRender component are below.

Archives
Latest Comment
Calendar
RSS
Tag Cloud